### PR TITLE
feat(contract): add late quorum oz extension to contract

### DIFF
--- a/contracts/SuperQuorumGov.sol
+++ b/contracts/SuperQuorumGov.sol
@@ -8,6 +8,7 @@ import "@openzeppelin/contracts/governance/extensions/GovernorStorage.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorPreventLateQuorum.sol";
 import "./extension/GovernorVotesSuperQuorumFraction.sol";
 
 /// @title SuperQuorumGovernor
@@ -20,6 +21,7 @@ contract SuperQuorumGovernor is
     GovernorVotes,
     GovernorVotesQuorumFraction,
     GovernorVotesSuperQuorumFraction,
+    GovernorPreventLateQuorum,
     GovernorTimelockControl
 {
     uint256 private _superQuorumThreshold;
@@ -167,6 +169,47 @@ contract SuperQuorumGovernor is
             calldatas,
             descriptionHash
         );
+    }
+
+    /**
+     * @notice Casts a vote on a proposal.
+     * @param proposalId The ID of the proposal to vote on.
+     * @param account The address of the voter.
+     * @param support The vote choice (true for yes, false for no).
+     * @param reason A brief description of the reason for the vote.
+     * @param params The parameters for the vote.
+     * @return The ID of the vote.
+     */
+    function _castVote(
+        uint256 proposalId,
+        address account,
+        uint8 support,
+        string memory reason,
+        bytes memory params
+    )
+        internal
+        virtual
+        override(Governor, GovernorPreventLateQuorum)
+        returns (uint256)
+    {
+        return super._castVote(proposalId, account, support, reason, params);
+    }
+
+    /**
+     *
+     * @notice Retrieves the deadline for submitting proposals.
+     * @param proposalId The ID of the proposal to query.
+     * @return The deadline for submitting proposals.
+     */
+    function proposalDeadline(
+        uint256 proposalId
+    )
+        public
+        view
+        override(Governor, GovernorPreventLateQuorum)
+        returns (uint256)
+    {
+        return super.proposalDeadline(proposalId);
     }
 
     function _cancel(

--- a/contracts/SuperQuorumGov.sol
+++ b/contracts/SuperQuorumGov.sol
@@ -25,7 +25,7 @@ contract SuperQuorumGovernor is
     GovernorTimelockControl
 {
     uint256 private _superQuorumThreshold;
-
+    
     /// @dev Initializes the governor contract with custom settings.
     /// @param _token Address of the governance token.
     /// @param _timelock Address of the timelock controller.
@@ -33,13 +33,15 @@ contract SuperQuorumGovernor is
     /// @param _votingPeriod Duration of the voting period.
     /// @param _votingDelay Delay before voting on a proposal starts.
     /// @param _proposalThreshold Minimum number of tokens required to create a proposal.
+    /// @param _initialVoteExtension Initial vote extension duration.
     constructor(
         IVotes _token,
         TimelockController _timelock,
         uint256 superQuorumThreshold,
         uint32 _votingPeriod,
         uint48 _votingDelay,
-        uint256 _proposalThreshold
+        uint256 _proposalThreshold,
+        uint48 _initialVoteExtension
     )
         Governor("MyGovernor")
         GovernorSettings(_votingDelay, _votingPeriod, _proposalThreshold)
@@ -47,6 +49,7 @@ contract SuperQuorumGovernor is
         GovernorVotesQuorumFraction(10)
         GovernorVotesSuperQuorumFraction(50)
         GovernorTimelockControl(_timelock)
+        GovernorPreventLateQuorum(_initialVoteExtension)
     {}
 
     /// @notice Returns the current state of a proposal.

--- a/test/SuperQuorumGov.ts
+++ b/test/SuperQuorumGov.ts
@@ -28,8 +28,10 @@ describe("SuperGovernor Contract", function () {
     let executionDelay = 0;
     const votingDelay = 0;
     const votingPeriod = 5; // 5 blocks
+    const extension = 0;
     const quorumFraction = 10;
     const superQuorumFraction = 50;
+    const proposalThreshold = 0;
 
     async function deploySetupFixture() {
         const superQuorum = 60 //60%
@@ -42,7 +44,7 @@ describe("SuperGovernor Contract", function () {
 
         const timelock = await timelock_factory.deploy(0, [], [], owner.address);
 
-        const governor = await SuperGovernor_factory.deploy(await token.getAddress(), await timelock.getAddress(), superQuorum, votingPeriod, votingDelay, 0);
+        const governor = await SuperGovernor_factory.deploy(await token.getAddress(), await timelock.getAddress(), superQuorum, votingPeriod, votingDelay, proposalThreshold,extension);
 
         await timelock.grantRole(await timelock.PROPOSER_ROLE(), await governor.getAddress());
         await timelock.grantRole(await timelock.EXECUTOR_ROLE(), await governor.getAddress());


### PR DESCRIPTION
I imported and added the LateQuorum extension as we support it in Tally as default already.

this allow us to use the already indexable event ProposalExtended.

<img width="655" alt="image" src="https://github.com/withtally/Governor-Super-Quorum/assets/26887703/6d929629-ebbe-4d05-9a2e-d824ae53258b">